### PR TITLE
Display subwindow icon on DockPaneStrip

### DIFF
--- a/WinFormsUI/ThemeVS2012/VS2012DockPaneStrip.cs
+++ b/WinFormsUI/ThemeVS2012/VS2012DockPaneStrip.cs
@@ -90,7 +90,7 @@ namespace WeifenLuo.WinFormsUI.Docking
         private const int _ToolWindowStripGapLeft = 0;
         private const int _ToolWindowStripGapRight = 0;
         private const int _ToolWindowImageHeight = 16;
-        private const int _ToolWindowImageWidth = 0;//16;
+        private const int _ToolWindowImageWidth = 16;//16;
         private const int _ToolWindowImageGapTop = 3;
         private const int _ToolWindowImageGapBottom = 1;
         private const int _ToolWindowImageGapLeft = 2;


### PR DESCRIPTION
Fixed an issue where the subwindow icons are not displayed.
![fleetlist](https://cloud.githubusercontent.com/assets/6127734/22578490/c268cc6c-e9fb-11e6-9b1d-d5237467ad5b.png)
